### PR TITLE
ci: add plugin manifest linting

### DIFF
--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -6,13 +6,19 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: codex-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Codex plugin scanner
-        uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0 # v1
         with:
           plugin_dir: "."
-

--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,18 @@
+name: Codex Plugin Quality Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Codex plugin scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@v1
+        with:
+          plugin_dir: "."
+


### PR DESCRIPTION
codex-be-serious is in awesome-codex-plugins. This adds a CI step to validate the manifest.

Action source: hashgraph-online/hol-codex-plugin-scanner-action